### PR TITLE
Speculated mega stats

### DIFF
--- a/data/megas.json
+++ b/data/megas.json
@@ -1,0 +1,1322 @@
+{
+	"items": [
+    
+	{
+		"templateId": "fake_mega",
+		"data": 
+	
+		{
+			"templateId": "V0065_POKEMON_ALAKAZAM_MEGA",
+			"pokemon": {
+				"uniqueId": "ALAKAZAM_MEGA",
+				"type1": "POKEMON_TYPE_PSYCHIC",
+				"stats": {
+					"baseStamina": 146,
+					"baseAttack": 367,
+					"baseDefense": 193
+				},
+				"quickMoves": [
+					"PSYCHO_CUT_FAST",
+					"CONFUSION_FAST"
+				],
+				"cinematicMoves": [
+					"FUTURESIGHT",
+					"FOCUS_BLAST",
+					"SHADOW_BALL",
+					"FIRE_PUNCH"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				},
+				"eliteQuickMove": [
+					"COUNTER_FAST"
+				],
+				"eliteCinematicMove": [
+					"DAZZLING_GLEAM",
+					"PSYCHIC"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0080_POKEMON_SLOWBRO_MEGA",
+			"pokemon": {
+				"uniqueId": "SLOWBRO_MEGA",
+				"type1": "POKEMON_TYPE_WATER",
+				"type2": "POKEMON_TYPE_PSYCHIC",
+				"stats": {
+					"baseStamina": 216,
+					"baseAttack": 224,
+					"baseDefense": 259
+				},
+				"quickMoves": [
+					"WATER_GUN_FAST",
+					"CONFUSION_FAST"
+				],
+				"cinematicMoves": [
+					"WATER_PULSE",
+					"PSYCHIC",
+					"ICE_BEAM"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0115_POKEMON_KANGASKHAN_MEGA",
+			"pokemon": {
+				"uniqueId": "KANGASKHAN_MEGA",
+				"type1": "POKEMON_TYPE_NORMAL",
+				"stats": {
+					"baseStamina": 233,
+					"baseAttack": 246,
+					"baseDefense": 210
+				},
+				"quickMoves": [
+					"MUD_SLAP_FAST",
+					"LOW_KICK_FAST"
+				],
+				"cinematicMoves": [
+					"CRUNCH",
+					"EARTHQUAKE",
+					"OUTRAGE",
+					"POWER_UP_PUNCH"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				},
+				"eliteCinematicMove": [
+					"BRICK_BREAK",
+					"STOMP"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0127_POKEMON_PINSIR_MEGA",
+			"pokemon": {
+				"uniqueId": "PINSIR_MEGA",
+				"type1": "POKEMON_TYPE_BUG",
+				"type2": "POKEMON_TYPE_FLYING",
+				"stats": {
+					"baseStamina": 163,
+					"baseAttack": 305,
+					"baseDefense": 231
+				},
+				"quickMoves": [
+					"ROCK_SMASH_FAST",
+					"BUG_BITE_FAST",
+					"FURY_CUTTER_FAST"
+				],
+				"cinematicMoves": [
+					"VICE_GRIP",
+					"X_SCISSOR",
+					"CLOSE_COMBAT",
+					"SUPER_POWER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				},
+				"eliteCinematicMove": [
+					"SUBMISSION"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0130_POKEMON_GYARADOS_MEGA",
+			"pokemon": {
+				"uniqueId": "GYARADOS_MEGA",
+				"type1": "POKEMON_TYPE_WATER",
+				"type2": "POKEMON_TYPE_DARK",
+				"stats": {
+					"baseStamina": 216,
+					"baseAttack": 292,
+					"baseDefense": 247
+				},
+				"quickMoves": [
+					"BITE_FAST",
+					"WATERFALL_FAST",
+					"DRAGON_BREATH_FAST"
+				],
+				"cinematicMoves": [
+					"HYDRO_PUMP",
+					"CRUNCH",
+					"OUTRAGE",
+					"TWISTER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 10000,
+					"candyToUnlock": 25
+				},
+				"eliteQuickMove": [
+					"DRAGON_TAIL_FAST"
+				],
+				"eliteCinematicMove": [
+					"DRAGON_PULSE"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0142_POKEMON_AERODACTYL_MEGA",
+			"pokemon": {
+				"uniqueId": "AERODACTYL_MEGA",
+				"type1": "POKEMON_TYPE_ROCK",
+				"type2": "POKEMON_TYPE_FLYING",
+				"stats": {
+					"baseStamina": 190,
+					"baseAttack": 292,
+					"baseDefense": 210
+				},
+				"quickMoves": [
+					"STEEL_WING_FAST",
+					"BITE_FAST",
+					"ROCK_THROW_FAST"
+				],
+				"cinematicMoves": [
+					"ANCIENT_POWER",
+					"IRON_HEAD",
+					"HYPER_BEAM",
+					"ROCK_SLIDE",
+					"EARTH_POWER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0150_POKEMON_MEWTWO_MEGA_X",
+			"pokemon": {
+				"uniqueId": "MEWTWO_MEGA_X",
+				"type1": "POKEMON_TYPE_PSYCHIC",
+				"type2": "POKEMON_TYPE_FIGHTING",
+				"stats": {
+					"baseStamina": 235,
+					"baseAttack": 412,
+					"baseDefense": 222
+				},
+				"quickMoves": [
+					"PSYCHO_CUT_FAST",
+					"CONFUSION_FAST"
+				],
+				"cinematicMoves": [
+					"PSYCHIC",
+					"THUNDERBOLT",
+					"ICE_BEAM",
+					"FOCUS_BLAST",
+					"FLAMETHROWER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 100000,
+					"candyToUnlock": 100
+				},
+				"eliteCinematicMove": [
+					"PSYSTRIKE",
+					"SHADOW_BALL",
+					"HYPER_BEAM"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0150_POKEMON_MEWTWO_MEGA_Y",
+			"pokemon": {
+				"uniqueId": "MEWTWO_MEGA_Y",
+				"type1": "POKEMON_TYPE_PSYCHIC",
+				"stats": {
+					"baseStamina": 235,
+					"baseAttack": 426,
+					"baseDefense": 229
+				},
+				"quickMoves": [
+					"PSYCHO_CUT_FAST",
+					"CONFUSION_FAST"
+				],
+				"cinematicMoves": [
+					"PSYCHIC",
+					"THUNDERBOLT",
+					"ICE_BEAM",
+					"FOCUS_BLAST",
+					"FLAMETHROWER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 100000,
+					"candyToUnlock": 100
+				},
+				"eliteCinematicMove": [
+					"PSYSTRIKE",
+					"SHADOW_BALL",
+					"HYPER_BEAM"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0181_POKEMON_AMPHAROS_MEGA",
+			"pokemon": {
+				"uniqueId": "AMPHAROS_MEGA",
+				"type1": "POKEMON_TYPE_ELECTRIC",
+				"type2": "POKEMON_TYPE_DRAGON",
+				"stats": {
+					"baseStamina": 207,
+					"baseAttack": 294,
+					"baseDefense": 203
+				},
+				"quickMoves": [
+					"CHARGE_BEAM_FAST",
+					"VOLT_SWITCH_FAST"
+				],
+				"cinematicMoves": [
+					"ZAP_CANNON",
+					"FOCUS_BLAST",
+					"THUNDER",
+					"POWER_GEM",
+					"THUNDER_PUNCH"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				},
+				"eliteCinematicMove": [
+					"DRAGON_PULSE"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0208_POKEMON_STEELIX_MEGA",
+			"pokemon": {
+				"uniqueId": "STEELIX_MEGA",
+				"type1": "POKEMON_TYPE_STEEL",
+				"type2": "POKEMON_TYPE_GROUND",
+				"stats": {
+					"baseStamina": 181,
+					"baseAttack": 212,
+					"baseDefense": 327
+				},
+				"quickMoves": [
+					"IRON_TAIL_FAST",
+					"DRAGON_TAIL_FAST",
+					"THUNDER_FANG_FAST"
+				],
+				"cinematicMoves": [
+					"EARTHQUAKE",
+					"HEAVY_SLAM",
+					"CRUNCH"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0212_POKEMON_SCIZOR_MEGA",
+			"pokemon": {
+				"uniqueId": "SCIZOR_MEGA",
+				"type1": "POKEMON_TYPE_BUG",
+				"type2": "POKEMON_TYPE_STEEL",
+				"stats": {
+					"baseStamina": 172,
+					"baseAttack": 279,
+					"baseDefense": 250
+				},
+				"quickMoves": [
+					"BULLET_PUNCH_FAST",
+					"FURY_CUTTER_FAST"
+				],
+				"cinematicMoves": [
+					"X_SCISSOR",
+					"IRON_HEAD",
+					"NIGHT_SLASH"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0214_POKEMON_HERACROSS_MEGA",
+			"pokemon": {
+				"uniqueId": "HERACROSS_MEGA",
+				"type1": "POKEMON_TYPE_BUG",
+				"type2": "POKEMON_TYPE_FIGHTING",
+				"stats": {
+					"baseStamina": 190,
+					"baseAttack": 334,
+					"baseDefense": 223
+				},
+				"quickMoves": [
+					"COUNTER_FAST",
+					"STRUGGLE_BUG_FAST"
+				],
+				"cinematicMoves": [
+					"MEGAHORN",
+					"CLOSE_COMBAT",
+					"EARTHQUAKE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0229_POKEMON_HOUNDOOM_MEGA",
+			"pokemon": {
+				"uniqueId": "HOUNDOOM_MEGA",
+				"type1": "POKEMON_TYPE_DARK",
+				"type2": "POKEMON_TYPE_FIRE",
+				"stats": {
+					"baseStamina": 181,
+					"baseAttack": 289,
+					"baseDefense": 194
+				},
+				"quickMoves": [
+					"SNARL_FAST",
+					"FIRE_FANG_FAST"
+				],
+				"cinematicMoves": [
+					"CRUNCH",
+					"FIRE_BLAST",
+					"FOUL_PLAY",
+					"FLAMETHROWER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0248_POKEMON_TYRANITAR_MEGA",
+			"pokemon": {
+				"uniqueId": "TYRANITAR_MEGA",
+				"type1": "POKEMON_TYPE_ROCK",
+				"type2": "POKEMON_TYPE_DARK",
+				"stats": {
+					"baseStamina": 225,
+					"baseAttack": 309,
+					"baseDefense": 276
+				},
+				"quickMoves": [
+					"BITE_FAST",
+					"IRON_TAIL_FAST"
+				],
+				"cinematicMoves": [
+					"FIRE_BLAST",
+					"CRUNCH",
+					"STONE_EDGE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				},
+				"eliteQuickMove": [
+					"SMACK_DOWN_FAST"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0254_POKEMON_SCEPTILE_MEGA",
+			"pokemon": {
+				"uniqueId": "SCEPTILE_MEGA",
+				"type1": "POKEMON_TYPE_GRASS",
+				"type2": "POKEMON_TYPE_DRAGON",
+				"stats": {
+					"baseStamina": 172,
+					"baseAttack": 320,
+					"baseDefense": 186
+				},
+				"quickMoves": [
+					"FURY_CUTTER_FAST",
+					"BULLET_SEED_FAST"
+				],
+				"cinematicMoves": [
+					"LEAF_BLADE",
+					"AERIAL_ACE",
+					"EARTHQUAKE",
+					"DRAGON_CLAW"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 10000,
+					"candyToUnlock": 25
+				},
+				"eliteCinematicMove": [
+					"FRENZY_PLANT"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0257_POKEMON_BLAZIKEN_MEGA",
+			"pokemon": {
+				"uniqueId": "BLAZIKEN_MEGA",
+				"type1": "POKEMON_TYPE_FIRE",
+				"type2": "POKEMON_TYPE_FIGHTING",
+				"stats": {
+					"baseStamina": 190,
+					"baseAttack": 329,
+					"baseDefense": 168
+				},
+				"quickMoves": [
+					"COUNTER_FAST",
+					"FIRE_SPIN_FAST"
+				],
+				"cinematicMoves": [
+					"FOCUS_BLAST",
+					"OVERHEAT",
+					"BRAVE_BIRD",
+					"BLAZE_KICK"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 10000,
+					"candyToUnlock": 25
+				},
+				"eliteCinematicMove": [
+					"BLAST_BURN",
+					"STONE_EDGE"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0260_POKEMON_SWAMPERT_MEGA",
+			"pokemon": {
+				"uniqueId": "SWAMPERT_MEGA",
+				"type1": "POKEMON_TYPE_WATER",
+				"type2": "POKEMON_TYPE_GROUND",
+				"stats": {
+					"baseStamina": 225,
+					"baseAttack": 283,
+					"baseDefense": 218
+				},
+				"quickMoves": [
+					"MUD_SHOT_FAST",
+					"WATER_GUN_FAST"
+				],
+				"cinematicMoves": [
+					"EARTHQUAKE",
+					"SLUDGE_WAVE",
+					"SURF",
+					"MUDDY_WATER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 10000,
+					"candyToUnlock": 25
+				},
+				"eliteCinematicMove": [
+					"HYDRO_CANNON"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0282_POKEMON_GARDEVOIR_MEGA",
+			"pokemon": {
+				"uniqueId": "GARDEVOIR_MEGA",
+				"type1": "POKEMON_TYPE_PSYCHIC",
+				"type2": "POKEMON_TYPE_FAIRY",
+				"stats": {
+					"baseStamina": 169,
+					"baseAttack": 326,
+					"baseDefense": 229
+				},
+				"quickMoves": [
+					"CONFUSION_FAST",
+					"CHARGE_BEAM_FAST",
+					"CHARM_FAST"
+				],
+				"cinematicMoves": [
+					"PSYCHIC",
+					"DAZZLING_GLEAM",
+					"SHADOW_BALL"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				},
+				"eliteCinematicMove": [
+					"SYNCHRONOISE"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0302_POKEMON_SABLEYE_MEGA",
+			"pokemon": {
+				"uniqueId": "SABLEYE_MEGA",
+				"type1": "POKEMON_TYPE_DARK",
+				"type2": "POKEMON_TYPE_GHOST",
+				"stats": {
+					"baseStamina": 137,
+					"baseAttack": 151,
+					"baseDefense": 216
+				},
+				"quickMoves": [
+					"SHADOW_CLAW_FAST",
+					"FEINT_ATTACK_FAST"
+				],
+				"cinematicMoves": [
+					"POWER_GEM",
+					"FOUL_PLAY",
+					"SHADOW_SNEAK"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0303_POKEMON_MAWILE_MEGA",
+			"pokemon": {
+				"uniqueId": "MAWILE_MEGA",
+				"type1": "POKEMON_TYPE_STEEL",
+				"type2": "POKEMON_TYPE_FAIRY",
+				"stats": {
+					"baseStamina": 137,
+					"baseAttack": 188,
+					"baseDefense": 217
+				},
+				"quickMoves": [
+					"BITE_FAST",
+					"ASTONISH_FAST",
+					"ICE_FANG_FAST",
+					"FIRE_FANG_FAST"
+				],
+				"cinematicMoves": [
+					"PLAY_ROUGH",
+					"VICE_GRIP",
+					"IRON_HEAD",
+					"POWER_UP_PUNCH"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0306_POKEMON_AGGRON_MEGA",
+			"pokemon": {
+				"uniqueId": "AGGRON_MEGA",
+				"type1": "POKEMON_TYPE_STEEL",
+				"quickMoves": [
+					"DRAGON_TAIL_FAST",
+					"IRON_TAIL_FAST",
+					"SMACK_DOWN_FAST"
+				],
+				"cinematicMoves": [
+					"THUNDER",
+					"STONE_EDGE",
+					"HEAVY_SLAM"
+				],
+				"stats": {
+					"baseStamina": 172,
+					"baseAttack": 247,
+					"baseDefense": 331
+				},
+				"thirdMove": {
+					"stardustToUnlock": 10000,
+					"candyToUnlock": 25
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0308_POKEMON_MEDICHAM_MEGA",
+			"pokemon": {
+				"uniqueId": "MEDICHAM_MEGA",
+				"type1": "POKEMON_TYPE_FIGHTING",
+				"type2": "POKEMON_TYPE_PSYCHIC",
+				"stats": {
+					"baseStamina": 155,
+					"baseAttack": 205,
+					"baseDefense": 179
+				},
+				"quickMoves": [
+					"PSYCHO_CUT_FAST",
+					"COUNTER_FAST"
+				],
+				"cinematicMoves": [
+					"ICE_PUNCH",
+					"PSYCHIC",
+					"DYNAMIC_PUNCH",
+					"POWER_UP_PUNCH"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0310_POKEMON_MANECTRIC_MEGA",
+			"pokemon": {
+				"uniqueId": "MANECTRIC_MEGA",
+				"type1": "POKEMON_TYPE_ELECTRIC",
+				"stats": {
+					"baseStamina": 172,
+					"baseAttack": 286,
+					"baseDefense": 179
+				},
+				"quickMoves": [
+					"SNARL_FAST",
+					"CHARGE_BEAM_FAST"
+				],
+				"cinematicMoves": [
+					"THUNDER",
+					"WILD_CHARGE",
+					"FLAME_BURST"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0319_POKEMON_SHARPEDO_MEGA",
+			"pokemon": {
+				"uniqueId": "SHARPEDO_MEGA",
+				"type1": "POKEMON_TYPE_WATER",
+				"type2": "POKEMON_TYPE_DARK",
+				"stats": {
+					"baseStamina": 172,
+					"baseAttack": 289,
+					"baseDefense": 144
+				},
+				"quickMoves": [
+					"BITE_FAST",
+					"WATERFALL_FAST"
+				],
+				"cinematicMoves": [
+					"HYDRO_PUMP",
+					"CRUNCH",
+					"POISON_FANG"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0323_POKEMON_CAMERUPT_MEGA",
+			"pokemon": {
+				"uniqueId": "CAMERUPT_MEGA",
+				"type1": "POKEMON_TYPE_FIRE",
+				"type2": "POKEMON_TYPE_GROUND",
+				"stats": {
+					"baseStamina": 172,
+					"baseAttack": 253,
+					"baseDefense": 183
+				},
+				"quickMoves": [
+					"EMBER_FAST",
+					"ROCK_SMASH_FAST"
+				],
+				"cinematicMoves": [
+					"EARTHQUAKE",
+					"OVERHEAT",
+					"SOLAR_BEAM",
+					"EARTH_POWER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0334_POKEMON_ALTARIA_MEGA",
+			"pokemon": {
+				"uniqueId": "ALTARIA_MEGA",
+				"type1": "POKEMON_TYPE_DRAGON",
+				"type2": "POKEMON_TYPE_FAIRY",
+				"stats": {
+					"baseStamina": 181,
+					"baseAttack": 222,
+					"baseDefense": 218
+				},
+				"quickMoves": [
+					"PECK_FAST",
+					"DRAGON_BREATH_FAST"
+				],
+				"cinematicMoves": [
+					"SKY_ATTACK",
+					"DAZZLING_GLEAM",
+					"DRAGON_PULSE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 10000,
+					"candyToUnlock": 25
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0354_POKEMON_BANETTE_MEGA",
+			"pokemon": {
+				"uniqueId": "BANETTE_MEGA",
+				"type1": "POKEMON_TYPE_GHOST",
+				"stats": {
+					"baseStamina": 162,
+					"baseAttack": 312,
+					"baseDefense": 160
+				},
+				"quickMoves": [
+					"HEX_FAST",
+					"SHADOW_CLAW_FAST"
+				],
+				"cinematicMoves": [
+					"SHADOW_BALL",
+					"DAZZLING_GLEAM",
+					"THUNDER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0359_POKEMON_ABSOL_MEGA",
+			"pokemon": {
+				"uniqueId": "ABSOL_MEGA",
+				"type1": "POKEMON_TYPE_DARK",
+				"stats": {
+					"baseStamina": 163,
+					"baseAttack": 314,
+					"baseDefense": 130
+				},
+				"quickMoves": [
+					"PSYCHO_CUT_FAST",
+					"SNARL_FAST"
+				],
+				"cinematicMoves": [
+					"DARK_PULSE",
+					"THUNDER",
+					"MEGAHORN"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0362_POKEMON_GLALIE_MEGA",
+			"pokemon": {
+				"uniqueId": "GLALIE_MEGA",
+				"type1": "POKEMON_TYPE_ICE",
+				"stats": {
+					"baseStamina": 190,
+					"baseAttack": 252,
+					"baseDefense": 168
+				},
+				"quickMoves": [
+					"ICE_SHARD_FAST",
+					"FROST_BREATH_FAST"
+				],
+				"cinematicMoves": [
+					"AVALANCHE",
+					"GYRO_BALL",
+					"SHADOW_BALL"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0373_POKEMON_SALAMENCE_MEGA",
+			"pokemon": {
+				"uniqueId": "SALAMENCE_MEGA",
+				"type1": "POKEMON_TYPE_DRAGON",
+				"type2": "POKEMON_TYPE_FLYING",
+				"stats": {
+					"baseStamina": 216,
+					"baseAttack": 310,
+					"baseDefense": 251
+				},
+				"quickMoves": [
+					"DRAGON_TAIL_FAST",
+					"FIRE_FANG_FAST",
+					"BITE_FAST"
+				],
+				"cinematicMoves": [
+					"FIRE_BLAST",
+					"HYDRO_PUMP",
+					"DRACO_METEOR"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				},
+				"eliteCinematicMove": [
+					"OUTRAGE"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0376_POKEMON_METAGROSS_MEGA",
+			"pokemon": {
+				"uniqueId": "METAGROSS_MEGA",
+				"type1": "POKEMON_TYPE_STEEL",
+				"type2": "POKEMON_TYPE_PSYCHIC",
+				"stats": {
+					"baseStamina": 190,
+					"baseAttack": 300,
+					"baseDefense": 289
+				},
+				"quickMoves": [
+					"BULLET_PUNCH_FAST",
+					"ZEN_HEADBUTT_FAST"
+				],
+				"cinematicMoves": [
+					"PSYCHIC",
+					"FLASH_CANNON",
+					"EARTHQUAKE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				},
+				"eliteCinematicMove": [
+					"METEOR_MASH"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0380_POKEMON_LATIAS_MEGA",
+			"pokemon": {
+				"uniqueId": "LATIAS_MEGA",
+				"type1": "POKEMON_TYPE_DRAGON",
+				"type2": "POKEMON_TYPE_PSYCHIC",
+				"stats": {
+					"baseStamina": 190,
+					"baseAttack": 289,
+					"baseDefense": 297
+				},
+				"quickMoves": [
+					"DRAGON_BREATH_FAST",
+					"ZEN_HEADBUTT_FAST",
+					"CHARM_FAST"
+				],
+				"cinematicMoves": [
+					"PSYCHIC",
+					"OUTRAGE",
+					"THUNDER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 100000,
+					"candyToUnlock": 100
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0381_POKEMON_LATIOS_MEGA",
+			"pokemon": {
+				"uniqueId": "LATIOS_MEGA",
+				"type1": "POKEMON_TYPE_DRAGON",
+				"type2": "POKEMON_TYPE_PSYCHIC",
+				"stats": {
+					"baseStamina": 190,
+					"baseAttack": 335,
+					"baseDefense": 241
+				},
+				"quickMoves": [
+					"DRAGON_BREATH_FAST",
+					"ZEN_HEADBUTT_FAST"
+				],
+				"cinematicMoves": [
+					"PSYCHIC",
+					"DRAGON_CLAW",
+					"SOLAR_BEAM"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 100000,
+					"candyToUnlock": 100
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0384_POKEMON_RAYQUAZA_MEGA",
+			"pokemon": {
+				"uniqueId": "RAYQUAZA_MEGA",
+				"type1": "POKEMON_TYPE_DRAGON",
+				"type2": "POKEMON_TYPE_FLYING",
+				"stats": {
+					"baseStamina": 233,
+					"baseAttack": 389,
+					"baseDefense": 216
+				},
+				"quickMoves": [
+					"AIR_SLASH_FAST",
+					"DRAGON_TAIL_FAST"
+				],
+				"cinematicMoves": [
+					"OUTRAGE",
+					"AERIAL_ACE",
+					"ANCIENT_POWER"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 100000,
+					"candyToUnlock": 100
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0428_POKEMON_LOPUNNY_MEGA",
+			"pokemon": {
+				"uniqueId": "LOPUNNY_MEGA",
+				"type1": "POKEMON_TYPE_NORMAL",
+				"type2": "POKEMON_TYPE_FIGHTING",
+				"stats": {
+					"baseStamina": 163,
+					"baseAttack": 282,
+					"baseDefense": 214
+				},
+				"quickMoves": [
+					"POUND_FAST",
+					"LOW_KICK_FAST"
+				],
+				"cinematicMoves": [
+					"FIRE_PUNCH",
+					"HYPER_BEAM",
+					"FOCUS_BLAST"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0445_POKEMON_GARCHOMP_MEGA",
+			"pokemon": {
+				"uniqueId": "GARCHOMP_MEGA",
+				"type1": "POKEMON_TYPE_DRAGON",
+				"type2": "POKEMON_TYPE_GROUND",
+				"stats": {
+					"baseStamina": 239,
+					"baseAttack": 339,
+					"baseDefense": 222
+				},
+				"quickMoves": [
+					"DRAGON_TAIL_FAST",
+					"MUD_SHOT_FAST"
+				],
+				"cinematicMoves": [
+					"OUTRAGE",
+					"EARTHQUAKE",
+					"FIRE_BLAST",
+					"SAND_TOMB"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0448_POKEMON_LUCARIO_MEGA",
+			"pokemon": {
+				"uniqueId": "LUCARIO_MEGA",
+				"type1": "POKEMON_TYPE_FIGHTING",
+				"type2": "POKEMON_TYPE_STEEL",
+				"stats": {
+					"baseStamina": 172,
+					"baseAttack": 310,
+					"baseDefense": 175
+				},
+				"quickMoves": [
+					"COUNTER_FAST",
+					"BULLET_PUNCH_FAST"
+				],
+				"cinematicMoves": [
+					"FLASH_CANNON",
+					"SHADOW_BALL",
+					"CLOSE_COMBAT",
+					"POWER_UP_PUNCH",
+					"AURA_SPHERE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0460_POKEMON_ABOMASNOW_MEGA",
+			"pokemon": {
+				"uniqueId": "ABOMASNOW_MEGA",
+				"type1": "POKEMON_TYPE_GRASS",
+				"type2": "POKEMON_TYPE_ICE",
+				"stats": {
+					"baseStamina": 207,
+					"baseAttack": 240,
+					"baseDefense": 191
+				},
+				"quickMoves": [
+					"POWDER_SNOW_FAST",
+					"RAZOR_LEAF_FAST"
+				],
+				"cinematicMoves": [
+					"BLIZZARD",
+					"ENERGY_BALL",
+					"OUTRAGE",
+					"WEATHER_BALL_ICE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0475_POKEMON_GALLADE_MEGA",
+			"pokemon": {
+				"uniqueId": "GALLADE_MEGA",
+				"type1": "POKEMON_TYPE_PSYCHIC",
+				"type2": "POKEMON_TYPE_FIGHTING",
+				"stats": {
+					"baseStamina": 169,
+					"baseAttack": 326,
+					"baseDefense": 230
+				},
+				"quickMoves": [
+					"CONFUSION_FAST",
+					"LOW_KICK_FAST",
+					"CHARM_FAST"
+				],
+				"cinematicMoves": [
+					"CLOSE_COMBAT",
+					"PSYCHIC",
+					"LEAF_BLADE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 75000,
+					"candyToUnlock": 75
+				},
+				"eliteCinematicMove": [
+					"SYNCHRONOISE"
+				]
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0531_POKEMON_AUDINO_MEGA",
+			"pokemon": {
+				"uniqueId": "AUDINO_MEGA",
+				"type1": "POKEMON_TYPE_NORMAL",
+				"type2": "POKEMON_TYPE_FAIRY",
+				"stats": {
+					"baseStamina": 230,
+					"baseAttack": 147,
+					"baseDefense": 239
+				},
+				"quickMoves": [
+					"POUND_FAST",
+					"ZEN_HEADBUTT_FAST"
+				],
+				"cinematicMoves": [
+					"DISARMING_VOICE",
+					"DAZZLING_GLEAM",
+					"HYPER_BEAM"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	},
+	{
+		"templateId": "fake_mega",
+		"data": 
+		{
+			"templateId": "V0719_POKEMON_DIANCIE_MEGA",
+			"pokemon": {
+				"uniqueId": "DIANCIE_MEGA",
+				"type1": "POKEMON_TYPE_FAIRY",
+				"type2": "POKEMON_TYPE_ROCK",
+				"stats": {
+					"baseStamina": 137,
+					"baseAttack": 342,
+					"baseDefense": 235
+				},
+				"quickMoves": [
+					"SMACK_DOWN_FAST",
+					"TACKLE_FAST"
+				],
+				"cinematicMoves": [
+					"DAZZLING_GLEAM",
+					"ANCIENT_POWER",
+					"STONE_EDGE"
+				],
+				"thirdMove": {
+					"stardustToUnlock": 50000,
+					"candyToUnlock": 50
+				}
+			}
+		}
+	
+	}
+		]
+}
+

--- a/data/megas.json
+++ b/data/megas.json
@@ -13,7 +13,7 @@
 				"stats": {
 					"baseStamina": 146,
 					"baseAttack": 367,
-					"baseDefense": 193
+					"baseDefense": 207
 				},
 				"quickMoves": [
 					"PSYCHO_CUT_FAST",

--- a/generate.js
+++ b/generate.js
@@ -409,6 +409,9 @@ function Add_Missing_Pokemon() {
             evos[tempEvoId].stamina !== stamina) {
           console.warn('Inconsistent guessed mega stats for', pokemon_id, tempEvoId);
         }
+        if (evos[tempEvoId].stamina !== GameMaster.pokemon[pokemon_id].stamina) {
+          console.warn('Stamina does not match existing values for', pokemon_id, tempEvoId);
+        }
       }
     }
     if (pokemon_id === 29) {

--- a/generate.js
+++ b/generate.js
@@ -403,7 +403,7 @@ function Add_Missing_Pokemon() {
       }
       for (const {tempEvoId, attack, defense, stamina} of guessedMega) {
         if (!evos[tempEvoId]) {
-          evos[tempEvoId] = {attack, defense, stamina};
+          evos[tempEvoId] = {attack, defense, stamina, unreleased: true};
         } else if (evos[tempEvoId].attack !== attack ||
             evos[tempEvoId].defense !== defense ||
             evos[tempEvoId].stamina !== stamina) {

--- a/generate.js
+++ b/generate.js
@@ -395,6 +395,11 @@ function Add_Missing_Pokemon() {
     if (!GameMaster.pokemon[pokemon_id].forms) {
       GameMaster.pokemon[pokemon_id].forms = {0: {}};
     }
+    if (pokemon_id === 29) {
+      for (let i = 776; i < 779; i++) {
+        GameMaster.pokemon[pokemon_id].forms[i].proto = GameMaster.pokemon[32].forms[i].proto;
+      }
+    }
     const guessedMega = megaStats[pokemon_id];
     if (guessedMega) {
       let evos = GameMaster.pokemon[pokemon_id].temp_evolutions;
@@ -415,6 +420,15 @@ function Add_Missing_Pokemon() {
             evo.types = types;
           }
           evos[tempEvoId] = evo;
+          for (const form of Object.values(GameMaster.pokemon[pokemon_id].forms)) {
+            const proto = form.proto || '';
+            if (proto.endsWith('_NORMAL') || proto.endsWith('_PURIFIED')) {
+              if (!form.temp_evolutions) {
+                form.temp_evolutions = {};
+              }
+              form.temp_evolutions[tempEvoId] = {};
+            }
+          }
         } else if (evos[tempEvoId].attack !== attack ||
             evos[tempEvoId].defense !== defense ||
             evos[tempEvoId].stamina !== stamina) {
@@ -423,11 +437,6 @@ function Add_Missing_Pokemon() {
         if (evos[tempEvoId].stamina !== GameMaster.pokemon[pokemon_id].stamina) {
           console.warn('Stamina does not match existing values for', pokemon_id, tempEvoId);
         }
-      }
-    }
-    if (pokemon_id === 29) {
-      for (let i = 776; i < 779; i++) {
-        GameMaster.pokemon[pokemon_id].forms[i].proto = GameMaster.pokemon[32].forms[i].proto;
       }
     }
   }

--- a/generate.js
+++ b/generate.js
@@ -401,9 +401,20 @@ function Add_Missing_Pokemon() {
       if (!evos) {
         evos = GameMaster.pokemon[pokemon_id].temp_evolutions = {};
       }
-      for (const {tempEvoId, attack, defense, stamina} of guessedMega) {
+      for (const {tempEvoId, attack, defense, stamina, type1, type2} of guessedMega) {
         if (!evos[tempEvoId]) {
-          evos[tempEvoId] = {attack, defense, stamina, unreleased: true};
+          let types = [];
+          if (type1) {
+            types.push(capitalize(type1.replace("POKEMON_TYPE_", "")));
+          }
+          if (type2) {
+            types.push(capitalize(type2.replace("POKEMON_TYPE_", "")));
+          }
+          const evo = {attack, defense, stamina, unreleased: true};
+          if (types.toString() != (GameMaster.pokemon[pokemon_id].types || {}).toString()) {
+            evo.types = types;
+          }
+          evos[tempEvoId] = evo;
         } else if (evos[tempEvoId].attack !== attack ||
             evos[tempEvoId].defense !== defense ||
             evos[tempEvoId].stamina !== stamina) {

--- a/master-latest.json
+++ b/master-latest.json
@@ -3970,7 +3970,10 @@
 			"forms": {
 				"310": {
 					"name": "Normal",
-					"proto": "ALAKAZAM_NORMAL"
+					"proto": "ALAKAZAM_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"311": {
 					"name": "Shadow",
@@ -3978,7 +3981,10 @@
 				},
 				"312": {
 					"name": "Purified",
-					"proto": "ALAKAZAM_PURIFIED"
+					"proto": "ALAKAZAM_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 310,
@@ -4014,7 +4020,8 @@
 				"1": {
 					"attack": 367,
 					"defense": 207,
-					"stamina": 146
+					"stamina": 146,
+					"unreleased": true
 				}
 			}
 		},
@@ -4959,7 +4966,10 @@
 			"forms": {
 				"1020": {
 					"name": "Normal",
-					"proto": "SLOWBRO_NORMAL"
+					"proto": "SLOWBRO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1021": {
 					"name": "Shadow",
@@ -4967,7 +4977,10 @@
 				},
 				"1022": {
 					"name": "Purified",
-					"proto": "SLOWBRO_PURIFIED"
+					"proto": "SLOWBRO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"2583": {
 					"name": "Galarian",
@@ -5007,7 +5020,8 @@
 				"1": {
 					"attack": 224,
 					"defense": 259,
-					"stamina": 216
+					"stamina": 216,
+					"unreleased": true
 				}
 			}
 		},
@@ -6996,7 +7010,10 @@
 			"forms": {
 				"839": {
 					"name": "Normal",
-					"proto": "KANGASKHAN_NORMAL"
+					"proto": "KANGASKHAN_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"840": {
 					"name": "Shadow",
@@ -7004,7 +7021,10 @@
 				},
 				"841": {
 					"name": "Purified",
-					"proto": "KANGASKHAN_PURIFIED"
+					"proto": "KANGASKHAN_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 839,
@@ -7040,7 +7060,8 @@
 				"1": {
 					"attack": 246,
 					"defense": 210,
-					"stamina": 233
+					"stamina": 233,
+					"unreleased": true
 				}
 			}
 		},
@@ -7627,7 +7648,10 @@
 			"forms": {
 				"898": {
 					"name": "Normal",
-					"proto": "PINSIR_NORMAL"
+					"proto": "PINSIR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"899": {
 					"name": "Shadow",
@@ -7635,7 +7659,10 @@
 				},
 				"900": {
 					"name": "Purified",
-					"proto": "PINSIR_PURIFIED"
+					"proto": "PINSIR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 898,
@@ -7672,7 +7699,12 @@
 				"1": {
 					"attack": 305,
 					"defense": 231,
-					"stamina": 163
+					"stamina": 163,
+					"unreleased": true,
+					"types": [
+						"Bug",
+						"Flying"
+					]
 				}
 			}
 		},
@@ -7788,7 +7820,10 @@
 			"forms": {
 				"256": {
 					"name": "Normal",
-					"proto": "GYARADOS_NORMAL"
+					"proto": "GYARADOS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"257": {
 					"name": "Shadow",
@@ -7796,7 +7831,10 @@
 				},
 				"258": {
 					"name": "Purified",
-					"proto": "GYARADOS_PURIFIED"
+					"proto": "GYARADOS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 256,
@@ -7834,7 +7872,12 @@
 				"1": {
 					"attack": 292,
 					"defense": 247,
-					"stamina": 216
+					"stamina": 216,
+					"unreleased": true,
+					"types": [
+						"Water",
+						"Dark"
+					]
 				}
 			}
 		},
@@ -8413,7 +8456,10 @@
 			"forms": {
 				"1110": {
 					"name": "Normal",
-					"proto": "AERODACTYL_NORMAL"
+					"proto": "AERODACTYL_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1111": {
 					"name": "Shadow",
@@ -8421,7 +8467,10 @@
 				},
 				"1112": {
 					"name": "Purified",
-					"proto": "AERODACTYL_PURIFIED"
+					"proto": "AERODACTYL_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1110,
@@ -8460,7 +8509,8 @@
 				"1": {
 					"attack": 292,
 					"defense": 210,
-					"stamina": 190
+					"stamina": 190,
+					"unreleased": true
 				}
 			}
 		},
@@ -8855,7 +8905,11 @@
 				},
 				"135": {
 					"name": "Normal",
-					"proto": "MEWTWO_NORMAL"
+					"proto": "MEWTWO_NORMAL",
+					"temp_evolutions": {
+						"2": {},
+						"3": {}
+					}
 				},
 				"1113": {
 					"name": "Shadow",
@@ -8863,7 +8917,11 @@
 				},
 				"1114": {
 					"name": "Purified",
-					"proto": "MEWTWO_PURIFIED"
+					"proto": "MEWTWO_PURIFIED",
+					"temp_evolutions": {
+						"2": {},
+						"3": {}
+					}
 				}
 			},
 			"default_form_id": 135,
@@ -8899,12 +8957,18 @@
 				"2": {
 					"attack": 412,
 					"defense": 222,
-					"stamina": 235
+					"stamina": 235,
+					"unreleased": true,
+					"types": [
+						"Psychic",
+						"Fighting"
+					]
 				},
 				"3": {
 					"attack": 426,
 					"defense": 229,
-					"stamina": 235
+					"stamina": 235,
+					"unreleased": true
 				}
 			}
 		},
@@ -10397,7 +10461,10 @@
 			"forms": {
 				"652": {
 					"name": "Normal",
-					"proto": "AMPHAROS_NORMAL"
+					"proto": "AMPHAROS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"653": {
 					"name": "Shadow",
@@ -10405,7 +10472,10 @@
 				},
 				"654": {
 					"name": "Purified",
-					"proto": "AMPHAROS_PURIFIED"
+					"proto": "AMPHAROS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 652,
@@ -10442,7 +10512,12 @@
 				"1": {
 					"attack": 294,
 					"defense": 203,
-					"stamina": 207
+					"stamina": 207,
+					"unreleased": true,
+					"types": [
+						"Electric",
+						"Dragon"
+					]
 				}
 			}
 		},
@@ -11888,7 +11963,10 @@
 			"forms": {
 				"905": {
 					"name": "Normal",
-					"proto": "STEELIX_NORMAL"
+					"proto": "STEELIX_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"906": {
 					"name": "Shadow",
@@ -11896,7 +11974,10 @@
 				},
 				"907": {
 					"name": "Purified",
-					"proto": "STEELIX_PURIFIED"
+					"proto": "STEELIX_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 905,
@@ -11933,7 +12014,8 @@
 				"1": {
 					"attack": 212,
 					"defense": 327,
-					"stamina": 181
+					"stamina": 181,
+					"unreleased": true
 				}
 			}
 		},
@@ -12084,7 +12166,10 @@
 			"forms": {
 				"250": {
 					"name": "Normal",
-					"proto": "SCIZOR_NORMAL"
+					"proto": "SCIZOR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"251": {
 					"name": "Shadow",
@@ -12092,7 +12177,10 @@
 				},
 				"252": {
 					"name": "Purified",
-					"proto": "SCIZOR_PURIFIED"
+					"proto": "SCIZOR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 250,
@@ -12128,7 +12216,8 @@
 				"1": {
 					"attack": 279,
 					"defense": 250,
-					"stamina": 172
+					"stamina": 172,
+					"unreleased": true
 				}
 			}
 		},
@@ -12183,7 +12272,10 @@
 			"forms": {
 				"1262": {
 					"name": "Normal",
-					"proto": "HERACROSS_NORMAL"
+					"proto": "HERACROSS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1263": {
 					"name": "Shadow",
@@ -12191,7 +12283,10 @@
 				},
 				"1264": {
 					"name": "Purified",
-					"proto": "HERACROSS_PURIFIED"
+					"proto": "HERACROSS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1262,
@@ -12227,7 +12322,8 @@
 				"1": {
 					"attack": 334,
 					"defense": 223,
-					"stamina": 190
+					"stamina": 190,
+					"unreleased": true
 				}
 			}
 		},
@@ -13909,7 +14005,10 @@
 			"forms": {
 				"319": {
 					"name": "Normal",
-					"proto": "TYRANITAR_NORMAL"
+					"proto": "TYRANITAR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"320": {
 					"name": "Shadow",
@@ -13917,7 +14016,10 @@
 				},
 				"321": {
 					"name": "Purified",
-					"proto": "TYRANITAR_PURIFIED"
+					"proto": "TYRANITAR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 319,
@@ -13953,7 +14055,8 @@
 				"1": {
 					"attack": 309,
 					"defense": 276,
-					"stamina": 225
+					"stamina": 225,
+					"unreleased": true
 				}
 			}
 		},
@@ -14195,7 +14298,10 @@
 			"forms": {
 				"1355": {
 					"name": "Normal",
-					"proto": "SCEPTILE_NORMAL"
+					"proto": "SCEPTILE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1356": {
 					"name": "Shadow",
@@ -14203,7 +14309,10 @@
 				},
 				"1357": {
 					"name": "Purified",
-					"proto": "SCEPTILE_PURIFIED"
+					"proto": "SCEPTILE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1355,
@@ -14239,7 +14348,12 @@
 				"1": {
 					"attack": 320,
 					"defense": 186,
-					"stamina": 172
+					"stamina": 172,
+					"unreleased": true,
+					"types": [
+						"Grass",
+						"Dragon"
+					]
 				}
 			}
 		},
@@ -14345,7 +14459,10 @@
 			"forms": {
 				"1364": {
 					"name": "Normal",
-					"proto": "BLAZIKEN_NORMAL"
+					"proto": "BLAZIKEN_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1365": {
 					"name": "Shadow",
@@ -14353,7 +14470,10 @@
 				},
 				"1366": {
 					"name": "Purified",
-					"proto": "BLAZIKEN_PURIFIED"
+					"proto": "BLAZIKEN_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1364,
@@ -14390,7 +14510,8 @@
 				"1": {
 					"attack": 329,
 					"defense": 168,
-					"stamina": 190
+					"stamina": 190,
+					"unreleased": true
 				}
 			}
 		},
@@ -14530,7 +14651,10 @@
 			"forms": {
 				"211": {
 					"name": "Normal",
-					"proto": "SWAMPERT_NORMAL"
+					"proto": "SWAMPERT_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"212": {
 					"name": "Shadow",
@@ -14538,7 +14662,10 @@
 				},
 				"213": {
 					"name": "Purified",
-					"proto": "SWAMPERT_PURIFIED"
+					"proto": "SWAMPERT_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 211,
@@ -14575,7 +14702,8 @@
 				"1": {
 					"attack": 283,
 					"defense": 218,
-					"stamina": 225
+					"stamina": 225,
+					"unreleased": true
 				}
 			}
 		},
@@ -15729,7 +15857,10 @@
 			"forms": {
 				"298": {
 					"name": "Normal",
-					"proto": "GARDEVOIR_NORMAL"
+					"proto": "GARDEVOIR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"299": {
 					"name": "Shadow",
@@ -15737,7 +15868,10 @@
 				},
 				"300": {
 					"name": "Purified",
-					"proto": "GARDEVOIR_PURIFIED"
+					"proto": "GARDEVOIR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 298,
@@ -15774,7 +15908,8 @@
 				"1": {
 					"attack": 326,
 					"defense": 229,
-					"stamina": 169
+					"stamina": 169,
+					"unreleased": true
 				}
 			}
 		},
@@ -16680,7 +16815,10 @@
 			"forms": {
 				"923": {
 					"name": "Normal",
-					"proto": "SABLEYE_NORMAL"
+					"proto": "SABLEYE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"924": {
 					"name": "Shadow",
@@ -16688,7 +16826,10 @@
 				},
 				"925": {
 					"name": "Purified",
-					"proto": "SABLEYE_PURIFIED"
+					"proto": "SABLEYE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"2666": {
 					"name": "Costume 2020 Deprecated",
@@ -16732,7 +16873,8 @@
 				"1": {
 					"attack": 151,
 					"defense": 216,
-					"stamina": 137
+					"stamina": 137,
+					"unreleased": true
 				}
 			}
 		},
@@ -16741,7 +16883,10 @@
 			"forms": {
 				"833": {
 					"name": "Normal",
-					"proto": "MAWILE_NORMAL"
+					"proto": "MAWILE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"834": {
 					"name": "Shadow",
@@ -16749,7 +16894,10 @@
 				},
 				"835": {
 					"name": "Purified",
-					"proto": "MAWILE_PURIFIED"
+					"proto": "MAWILE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 833,
@@ -16788,7 +16936,8 @@
 				"1": {
 					"attack": 188,
 					"defense": 217,
-					"stamina": 137
+					"stamina": 137,
+					"unreleased": true
 				}
 			}
 		},
@@ -16895,7 +17044,10 @@
 			"forms": {
 				"1475": {
 					"name": "Normal",
-					"proto": "AGGRON_NORMAL"
+					"proto": "AGGRON_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1476": {
 					"name": "Shadow",
@@ -16903,7 +17055,10 @@
 				},
 				"1477": {
 					"name": "Purified",
-					"proto": "AGGRON_PURIFIED"
+					"proto": "AGGRON_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1475,
@@ -16940,7 +17095,11 @@
 				"1": {
 					"attack": 247,
 					"defense": 331,
-					"stamina": 172
+					"stamina": 172,
+					"unreleased": true,
+					"types": [
+						"Steel"
+					]
 				}
 			}
 		},
@@ -16998,7 +17157,10 @@
 			"forms": {
 				"1481": {
 					"name": "Normal",
-					"proto": "MEDICHAM_NORMAL"
+					"proto": "MEDICHAM_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1482": {
 					"name": "Shadow",
@@ -17006,7 +17168,10 @@
 				},
 				"1483": {
 					"name": "Purified",
-					"proto": "MEDICHAM_PURIFIED"
+					"proto": "MEDICHAM_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1481,
@@ -17043,7 +17208,8 @@
 				"1": {
 					"attack": 205,
 					"defense": 179,
-					"stamina": 155
+					"stamina": 155,
+					"unreleased": true
 				}
 			}
 		},
@@ -17100,7 +17266,10 @@
 			"forms": {
 				"1487": {
 					"name": "Normal",
-					"proto": "MANECTRIC_NORMAL"
+					"proto": "MANECTRIC_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1488": {
 					"name": "Shadow",
@@ -17108,7 +17277,10 @@
 				},
 				"1489": {
 					"name": "Purified",
-					"proto": "MANECTRIC_PURIFIED"
+					"proto": "MANECTRIC_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1487,
@@ -17143,7 +17315,8 @@
 				"1": {
 					"attack": 286,
 					"defense": 179,
-					"stamina": 172
+					"stamina": 172,
+					"unreleased": true
 				}
 			}
 		},
@@ -17543,7 +17716,10 @@
 			"forms": {
 				"737": {
 					"name": "Normal",
-					"proto": "SHARPEDO_NORMAL"
+					"proto": "SHARPEDO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"738": {
 					"name": "Shadow",
@@ -17551,7 +17727,10 @@
 				},
 				"739": {
 					"name": "Purified",
-					"proto": "SHARPEDO_PURIFIED"
+					"proto": "SHARPEDO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 737,
@@ -17587,7 +17766,8 @@
 				"1": {
 					"attack": 289,
 					"defense": 144,
-					"stamina": 172
+					"stamina": 172,
+					"unreleased": true
 				}
 			}
 		},
@@ -17738,7 +17918,10 @@
 			"forms": {
 				"1520": {
 					"name": "Normal",
-					"proto": "CAMERUPT_NORMAL"
+					"proto": "CAMERUPT_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1521": {
 					"name": "Shadow",
@@ -17746,7 +17929,10 @@
 				},
 				"1522": {
 					"name": "Purified",
-					"proto": "CAMERUPT_PURIFIED"
+					"proto": "CAMERUPT_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1520,
@@ -17783,7 +17969,8 @@
 				"1": {
 					"attack": 253,
 					"defense": 183,
-					"stamina": 172
+					"stamina": 172,
+					"unreleased": true
 				}
 			}
 		},
@@ -18380,7 +18567,10 @@
 			"forms": {
 				"1535": {
 					"name": "Normal",
-					"proto": "ALTARIA_NORMAL"
+					"proto": "ALTARIA_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1536": {
 					"name": "Shadow",
@@ -18388,7 +18578,10 @@
 				},
 				"1537": {
 					"name": "Purified",
-					"proto": "ALTARIA_PURIFIED"
+					"proto": "ALTARIA_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1535,
@@ -18424,7 +18617,12 @@
 				"1": {
 					"attack": 222,
 					"defense": 218,
-					"stamina": 181
+					"stamina": 181,
+					"unreleased": true,
+					"types": [
+						"Dragon",
+						"Fairy"
+					]
 				}
 			}
 		},
@@ -19386,7 +19584,10 @@
 			"forms": {
 				"911": {
 					"name": "Normal",
-					"proto": "BANETTE_NORMAL"
+					"proto": "BANETTE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"912": {
 					"name": "Shadow",
@@ -19394,7 +19595,10 @@
 				},
 				"913": {
 					"name": "Purified",
-					"proto": "BANETTE_PURIFIED"
+					"proto": "BANETTE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 911,
@@ -19429,7 +19633,8 @@
 				"1": {
 					"attack": 312,
 					"defense": 160,
-					"stamina": 162
+					"stamina": 162,
+					"unreleased": true
 				}
 			}
 		},
@@ -19660,7 +19865,10 @@
 			"forms": {
 				"830": {
 					"name": "Normal",
-					"proto": "ABSOL_NORMAL"
+					"proto": "ABSOL_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"831": {
 					"name": "Shadow",
@@ -19668,7 +19876,10 @@
 				},
 				"832": {
 					"name": "Purified",
-					"proto": "ABSOL_PURIFIED"
+					"proto": "ABSOL_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 830,
@@ -19703,7 +19914,8 @@
 				"1": {
 					"attack": 314,
 					"defense": 130,
-					"stamina": 163
+					"stamina": 163,
+					"unreleased": true
 				}
 			}
 		},
@@ -19809,7 +20021,10 @@
 			"forms": {
 				"929": {
 					"name": "Normal",
-					"proto": "GLALIE_NORMAL"
+					"proto": "GLALIE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"930": {
 					"name": "Shadow",
@@ -19817,7 +20032,10 @@
 				},
 				"931": {
 					"name": "Purified",
-					"proto": "GLALIE_PURIFIED"
+					"proto": "GLALIE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 929,
@@ -19852,7 +20070,8 @@
 				"1": {
 					"attack": 252,
 					"defense": 168,
-					"stamina": 190
+					"stamina": 190,
+					"unreleased": true
 				}
 			}
 		},
@@ -20364,7 +20583,10 @@
 			"forms": {
 				"761": {
 					"name": "Normal",
-					"proto": "SALAMENCE_NORMAL"
+					"proto": "SALAMENCE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"762": {
 					"name": "Shadow",
@@ -20372,7 +20594,10 @@
 				},
 				"763": {
 					"name": "Purified",
-					"proto": "SALAMENCE_PURIFIED"
+					"proto": "SALAMENCE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 761,
@@ -20409,7 +20634,8 @@
 				"1": {
 					"attack": 310,
 					"defense": 251,
-					"stamina": 216
+					"stamina": 216,
+					"unreleased": true
 				}
 			}
 		},
@@ -20545,7 +20771,10 @@
 			"forms": {
 				"770": {
 					"name": "Normal",
-					"proto": "METAGROSS_NORMAL"
+					"proto": "METAGROSS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"771": {
 					"name": "Shadow",
@@ -20553,7 +20782,10 @@
 				},
 				"772": {
 					"name": "Purified",
-					"proto": "METAGROSS_PURIFIED"
+					"proto": "METAGROSS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 770,
@@ -20589,7 +20821,8 @@
 				"1": {
 					"attack": 300,
 					"defense": 289,
-					"stamina": 190
+					"stamina": 190,
+					"unreleased": true
 				}
 			}
 		},
@@ -20733,7 +20966,10 @@
 			"forms": {
 				"1631": {
 					"name": "Normal",
-					"proto": "LATIAS_NORMAL"
+					"proto": "LATIAS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1632": {
 					"name": "Shadow",
@@ -20741,7 +20977,10 @@
 				},
 				"1633": {
 					"name": "Purified",
-					"proto": "LATIAS_PURIFIED"
+					"proto": "LATIAS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1631,
@@ -20777,7 +21016,8 @@
 				"1": {
 					"attack": 289,
 					"defense": 297,
-					"stamina": 190
+					"stamina": 190,
+					"unreleased": true
 				}
 			}
 		},
@@ -20786,7 +21026,10 @@
 			"forms": {
 				"1634": {
 					"name": "Normal",
-					"proto": "LATIOS_NORMAL"
+					"proto": "LATIOS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1635": {
 					"name": "Shadow",
@@ -20794,7 +21037,10 @@
 				},
 				"1636": {
 					"name": "Purified",
-					"proto": "LATIOS_PURIFIED"
+					"proto": "LATIOS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1634,
@@ -20829,7 +21075,8 @@
 				"1": {
 					"attack": 335,
 					"defense": 241,
-					"stamina": 190
+					"stamina": 190,
+					"unreleased": true
 				}
 			}
 		},
@@ -20926,7 +21173,10 @@
 			"forms": {
 				"1643": {
 					"name": "Normal",
-					"proto": "RAYQUAZA_NORMAL"
+					"proto": "RAYQUAZA_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1644": {
 					"name": "Shadow",
@@ -20934,7 +21184,10 @@
 				},
 				"1645": {
 					"name": "Purified",
-					"proto": "RAYQUAZA_PURIFIED"
+					"proto": "RAYQUAZA_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1643,
@@ -20969,7 +21222,8 @@
 				"1": {
 					"attack": 389,
 					"defense": 216,
-					"stamina": 233
+					"stamina": 233,
+					"unreleased": true
 				}
 			}
 		},
@@ -23242,7 +23496,10 @@
 			"forms": {
 				"1754": {
 					"name": "Normal",
-					"proto": "LOPUNNY_NORMAL"
+					"proto": "LOPUNNY_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1755": {
 					"name": "Shadow",
@@ -23250,7 +23507,10 @@
 				},
 				"1756": {
 					"name": "Purified",
-					"proto": "LOPUNNY_PURIFIED"
+					"proto": "LOPUNNY_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1754,
@@ -23285,7 +23545,12 @@
 				"1": {
 					"attack": 282,
 					"defense": 214,
-					"stamina": 163
+					"stamina": 163,
+					"unreleased": true,
+					"types": [
+						"Normal",
+						"Fighting"
+					]
 				}
 			}
 		},
@@ -24103,7 +24368,10 @@
 			"forms": {
 				"867": {
 					"name": "Normal",
-					"proto": "GARCHOMP_NORMAL"
+					"proto": "GARCHOMP_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"868": {
 					"name": "Shadow",
@@ -24111,7 +24379,10 @@
 				},
 				"869": {
 					"name": "Purified",
-					"proto": "GARCHOMP_PURIFIED"
+					"proto": "GARCHOMP_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 867,
@@ -24148,7 +24419,8 @@
 				"1": {
 					"attack": 339,
 					"defense": 222,
-					"stamina": 239
+					"stamina": 239,
+					"unreleased": true
 				}
 			}
 		},
@@ -24252,7 +24524,10 @@
 			"forms": {
 				"1793": {
 					"name": "Normal",
-					"proto": "LUCARIO_NORMAL"
+					"proto": "LUCARIO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1794": {
 					"name": "Shadow",
@@ -24260,7 +24535,10 @@
 				},
 				"1795": {
 					"name": "Purified",
-					"proto": "LUCARIO_PURIFIED"
+					"proto": "LUCARIO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1793,
@@ -24298,7 +24576,8 @@
 				"1": {
 					"attack": 310,
 					"defense": 175,
-					"stamina": 172
+					"stamina": 172,
+					"unreleased": true
 				}
 			}
 		},
@@ -24866,7 +25145,10 @@
 			"forms": {
 				"935": {
 					"name": "Normal",
-					"proto": "ABOMASNOW_NORMAL"
+					"proto": "ABOMASNOW_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"936": {
 					"name": "Shadow",
@@ -24874,7 +25156,10 @@
 				},
 				"937": {
 					"name": "Purified",
-					"proto": "ABOMASNOW_PURIFIED"
+					"proto": "ABOMASNOW_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 935,
@@ -24911,7 +25196,8 @@
 				"1": {
 					"attack": 240,
 					"defense": 191,
-					"stamina": 207
+					"stamina": 207,
+					"unreleased": true
 				}
 			}
 		},
@@ -25571,7 +25857,10 @@
 			"forms": {
 				"301": {
 					"name": "Normal",
-					"proto": "GALLADE_NORMAL"
+					"proto": "GALLADE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"302": {
 					"name": "Shadow",
@@ -25579,7 +25868,10 @@
 				},
 				"303": {
 					"name": "Purified",
-					"proto": "GALLADE_PURIFIED"
+					"proto": "GALLADE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 301,
@@ -25616,7 +25908,8 @@
 				"1": {
 					"attack": 326,
 					"defense": 230,
-					"stamina": 169
+					"stamina": 169,
+					"unreleased": true
 				}
 			}
 		},
@@ -28378,7 +28671,10 @@
 			"forms": {
 				"1997": {
 					"name": "Normal",
-					"proto": "AUDINO_NORMAL"
+					"proto": "AUDINO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1998": {
 					"name": "Shadow",
@@ -28386,7 +28682,10 @@
 				},
 				"1999": {
 					"name": "Purified",
-					"proto": "AUDINO_PURIFIED"
+					"proto": "AUDINO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1997,
@@ -28421,7 +28720,12 @@
 				"1": {
 					"attack": 147,
 					"defense": 239,
-					"stamina": 230
+					"stamina": 230,
+					"unreleased": true,
+					"types": [
+						"Normal",
+						"Fairy"
+					]
 				}
 			}
 		},
@@ -34871,7 +35175,12 @@
 				"1": {
 					"attack": 342,
 					"defense": 235,
-					"stamina": 137
+					"stamina": 137,
+					"unreleased": true,
+					"types": [
+						"Fairy",
+						"Rock"
+					]
 				}
 			}
 		},

--- a/master-latest.json
+++ b/master-latest.json
@@ -4013,7 +4013,7 @@
 			"temp_evolutions": {
 				"1": {
 					"attack": 367,
-					"defense": 193,
+					"defense": 207,
 					"stamina": 146
 				}
 			}

--- a/master-latest.json
+++ b/master-latest.json
@@ -4009,7 +4009,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 367,
+					"defense": 193,
+					"stamina": 146
+				}
+			}
 		},
 		"66": {
 			"name": "Machop",
@@ -4995,7 +5002,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 224,
+					"defense": 259,
+					"stamina": 216
+				}
+			}
 		},
 		"81": {
 			"name": "Magnemite",
@@ -7021,7 +7035,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 246,
+					"defense": 210,
+					"stamina": 233
+				}
+			}
 		},
 		"116": {
 			"name": "Horsea",
@@ -7646,7 +7667,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 305,
+					"defense": 231,
+					"stamina": 163
+				}
+			}
 		},
 		"128": {
 			"name": "Tauros",
@@ -7801,7 +7829,14 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 292,
+					"defense": 247,
+					"stamina": 216
+				}
+			}
 		},
 		"131": {
 			"name": "Lapras",
@@ -8420,7 +8455,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 292,
+					"defense": 210,
+					"stamina": 190
+				}
+			}
 		},
 		"143": {
 			"name": "Snorlax",
@@ -8852,7 +8894,19 @@
 			"buddy_group_number": 3,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"2": {
+					"attack": 412,
+					"defense": 222,
+					"stamina": 235
+				},
+				"3": {
+					"attack": 426,
+					"defense": 229,
+					"stamina": 235
+				}
+			}
 		},
 		"151": {
 			"name": "Mew",
@@ -10383,7 +10437,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 294,
+					"defense": 203,
+					"stamina": 207
+				}
+			}
 		},
 		"182": {
 			"name": "Bellossom",
@@ -11867,7 +11928,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 212,
+					"defense": 327,
+					"stamina": 181
+				}
+			}
 		},
 		"209": {
 			"name": "Snubbull",
@@ -12055,7 +12123,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 279,
+					"defense": 250,
+					"stamina": 172
+				}
+			}
 		},
 		"213": {
 			"name": "Shuckle",
@@ -12147,7 +12222,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 334,
+					"defense": 223,
+					"stamina": 190
+				}
+			}
 		},
 		"215": {
 			"name": "Sneasel",
@@ -13866,7 +13948,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 309,
+					"defense": 276,
+					"stamina": 225
+				}
+			}
 		},
 		"249": {
 			"name": "Lugia",
@@ -14145,7 +14234,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 320,
+					"defense": 186,
+					"stamina": 172
+				}
+			}
 		},
 		"255": {
 			"name": "Torchic",
@@ -14289,7 +14385,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 329,
+					"defense": 168,
+					"stamina": 190
+				}
+			}
 		},
 		"258": {
 			"name": "Mudkip",
@@ -14467,7 +14570,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 283,
+					"defense": 218,
+					"stamina": 225
+				}
+			}
 		},
 		"261": {
 			"name": "Poochyena",
@@ -15659,7 +15769,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 326,
+					"defense": 229,
+					"stamina": 169
+				}
+			}
 		},
 		"283": {
 			"name": "Surskit",
@@ -16610,7 +16727,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 151,
+					"defense": 216,
+					"stamina": 137
+				}
+			}
 		},
 		"303": {
 			"name": "Mawile",
@@ -16659,7 +16783,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 188,
+					"defense": 217,
+					"stamina": 137
+				}
+			}
 		},
 		"304": {
 			"name": "Aron",
@@ -16804,7 +16935,14 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 247,
+					"defense": 331,
+					"stamina": 172
+				}
+			}
 		},
 		"307": {
 			"name": "Meditite",
@@ -16900,7 +17038,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 205,
+					"defense": 179,
+					"stamina": 155
+				}
+			}
 		},
 		"309": {
 			"name": "Electrike",
@@ -16993,7 +17138,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 286,
+					"defense": 179,
+					"stamina": 172
+				}
+			}
 		},
 		"311": {
 			"name": "Plusle",
@@ -17430,7 +17582,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 289,
+					"defense": 144,
+					"stamina": 172
+				}
+			}
 		},
 		"320": {
 			"name": "Wailmer",
@@ -17619,7 +17778,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 253,
+					"defense": 183,
+					"stamina": 172
+				}
+			}
 		},
 		"324": {
 			"name": "Torkoal",
@@ -18253,7 +18419,14 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 222,
+					"defense": 218,
+					"stamina": 181
+				}
+			}
 		},
 		"335": {
 			"name": "Zangoose",
@@ -19251,7 +19424,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 312,
+					"defense": 160,
+					"stamina": 162
+				}
+			}
 		},
 		"355": {
 			"name": "Duskull",
@@ -19518,7 +19698,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 314,
+					"defense": 130,
+					"stamina": 163
+				}
+			}
 		},
 		"360": {
 			"name": "Wynaut",
@@ -19660,7 +19847,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 252,
+					"defense": 168,
+					"stamina": 190
+				}
+			}
 		},
 		"363": {
 			"name": "Spheal",
@@ -20210,7 +20404,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 310,
+					"defense": 251,
+					"stamina": 216
+				}
+			}
 		},
 		"374": {
 			"name": "Beldum",
@@ -20383,7 +20584,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 300,
+					"defense": 289,
+					"stamina": 190
+				}
+			}
 		},
 		"377": {
 			"name": "Regirock",
@@ -20564,7 +20772,14 @@
 			"buddy_group_number": 7,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"1": {
+					"attack": 289,
+					"defense": 297,
+					"stamina": 190
+				}
+			}
 		},
 		"381": {
 			"name": "Latios",
@@ -20609,7 +20824,14 @@
 			"buddy_group_number": 7,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"1": {
+					"attack": 335,
+					"defense": 241,
+					"stamina": 190
+				}
+			}
 		},
 		"382": {
 			"name": "Kyogre",
@@ -20742,7 +20964,14 @@
 			"buddy_group_number": 7,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"1": {
+					"attack": 389,
+					"defense": 216,
+					"stamina": 233
+				}
+			}
 		},
 		"385": {
 			"name": "Jirachi",
@@ -23051,7 +23280,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 282,
+					"defense": 214,
+					"stamina": 163
+				}
+			}
 		},
 		"429": {
 			"name": "Mismagius",
@@ -23907,7 +24143,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 339,
+					"defense": 222,
+					"stamina": 239
+				}
+			}
 		},
 		"446": {
 			"name": "Munchlax",
@@ -24050,7 +24293,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 310,
+					"defense": 175,
+					"stamina": 172
+				}
+			}
 		},
 		"449": {
 			"name": "Hippopotas",
@@ -24656,7 +24906,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 240,
+					"defense": 191,
+					"stamina": 207
+				}
+			}
 		},
 		"461": {
 			"name": "Weavile",
@@ -25354,7 +25611,14 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 326,
+					"defense": 230,
+					"stamina": 169
+				}
+			}
 		},
 		"476": {
 			"name": "Probopass",
@@ -28152,7 +28416,14 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 147,
+					"defense": 239,
+					"stamina": 230
+				}
+			}
 		},
 		"532": {
 			"name": "Timburr",
@@ -34595,6 +34866,13 @@
 			"name": "Diancie",
 			"forms": {
 				"0": {}
+			},
+			"temp_evolutions": {
+				"1": {
+					"attack": 342,
+					"defense": 235,
+					"stamina": 137
+				}
 			}
 		},
 		"720": {


### PR DESCRIPTION
Data courtesy of PokeBattlers, cross checked with pogostat.com. The only inconsistency that I found is due to Mega Alakazam's sp def being buffed 10 points in gen 7. The dataset currently takes the gen7 data.