### PR TITLE
Little cup support

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -473,9 +473,8 @@ function Add_Little_Cup() {
     GameMaster.pokemon[Pokemon_List.FARFETCHD].forms[Form_List.FARFETCHD_GALARIAN].little = true;
   }
   for (const [pokemonId, pokemon] of Object.entries(GameMaster.pokemon)) {
-    const allowed = pokemonId != Pokemon_List.OMANYTE && (  // OMANYTE was banned due to an exploit
-        pokemonId == Pokemon_List.DEERLING ||               // for some reason FORM_UNSET DEERLING cannot evolve
-        !evolvedPokemon.has(parseInt(pokemonId)) && pokemon.evolutions !== undefined);
+    const allowed = pokemonId == Pokemon_List.DEERLING ||   // for some reason FORM_UNSET DEERLING cannot evolve
+        !evolvedPokemon.has(parseInt(pokemonId)) && pokemon.evolutions !== undefined;
     if (allowed) {
       pokemon.little = true;
     }

--- a/master-latest.json
+++ b/master-latest.json
@@ -9027,7 +9027,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"139": {
 			"name": "Omastar",

--- a/master-latest.json
+++ b/master-latest.json
@@ -74,7 +74,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"2": {
 			"name": "Ivysaur",
@@ -288,7 +289,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"5": {
 			"name": "Charmeleon",
@@ -512,7 +514,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"8": {
 			"name": "Wartortle",
@@ -699,7 +702,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"11": {
 			"name": "Metapod",
@@ -867,7 +871,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"14": {
 			"name": "Kakuna",
@@ -1054,7 +1059,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"17": {
 			"name": "Pidgeotto",
@@ -1256,7 +1262,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"20": {
 			"name": "Raticate",
@@ -1378,7 +1385,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"22": {
 			"name": "Fearow",
@@ -1497,7 +1505,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"24": {
 			"name": "Arbok",
@@ -1815,7 +1824,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"28": {
 			"name": "Sandslash",
@@ -1956,7 +1966,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"30": {
 			"name": "Nidorina",
@@ -2147,7 +2158,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"33": {
 			"name": "Nidorino",
@@ -2463,7 +2475,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"38": {
 			"name": "Ninetales",
@@ -2710,7 +2723,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"42": {
 			"name": "Golbat",
@@ -2854,7 +2868,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"44": {
 			"name": "Gloom",
@@ -3044,7 +3059,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"47": {
 			"name": "Parasect",
@@ -3164,7 +3180,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"49": {
 			"name": "Venomoth",
@@ -3307,7 +3324,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"51": {
 			"name": "Dugtrio",
@@ -3493,7 +3511,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"53": {
 			"name": "Persian",
@@ -3630,7 +3649,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"55": {
 			"name": "Golduck",
@@ -3732,7 +3752,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"57": {
 			"name": "Primeape",
@@ -3851,7 +3872,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"59": {
 			"name": "Arcanine",
@@ -3971,7 +3993,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"61": {
 			"name": "Poliwhirl",
@@ -4179,7 +4202,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"64": {
 			"name": "Kadabra",
@@ -4383,7 +4407,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"67": {
 			"name": "Machoke",
@@ -4575,7 +4600,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"70": {
 			"name": "Weepinbell",
@@ -4750,7 +4776,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"73": {
 			"name": "Tentacruel",
@@ -4896,7 +4923,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"75": {
 			"name": "Graveler",
@@ -5156,7 +5184,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"78": {
 			"name": "Rapidash",
@@ -5327,7 +5356,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"80": {
 			"name": "Slowbro",
@@ -5469,7 +5499,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"82": {
 			"name": "Magneton",
@@ -5584,7 +5615,8 @@
 					],
 					"types": [
 						"Fighting"
-					]
+					],
+					"little": true
 				}
 			},
 			"default_form_id": 1023,
@@ -5670,7 +5702,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"85": {
 			"name": "Dodrio",
@@ -5770,7 +5803,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"87": {
 			"name": "Dewgong",
@@ -5914,7 +5948,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"89": {
 			"name": "Muk",
@@ -6055,7 +6090,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"91": {
 			"name": "Cloyster",
@@ -6157,7 +6193,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"93": {
 			"name": "Haunter",
@@ -6354,7 +6391,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"96": {
 			"name": "Drowzee",
@@ -6425,7 +6463,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"97": {
 			"name": "Hypno",
@@ -6547,7 +6586,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"99": {
 			"name": "Kingler",
@@ -6647,7 +6687,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"101": {
 			"name": "Electrode",
@@ -6767,7 +6808,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"103": {
 			"name": "Exeggutor",
@@ -6909,7 +6951,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"105": {
 			"name": "Marowak",
@@ -7125,7 +7168,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"109": {
 			"name": "Koffing",
@@ -7196,7 +7240,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"110": {
 			"name": "Weezing",
@@ -7336,7 +7381,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"112": {
 			"name": "Rhydon",
@@ -7531,7 +7577,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"115": {
 			"name": "Kangaskhan",
@@ -7664,7 +7711,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"117": {
 			"name": "Seadra",
@@ -7787,7 +7835,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"119": {
 			"name": "Seaking",
@@ -7886,7 +7935,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"121": {
 			"name": "Starmie",
@@ -8080,7 +8130,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"124": {
 			"name": "Jynx",
@@ -8453,7 +8504,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"130": {
 			"name": "Gyarados",
@@ -8690,7 +8742,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"134": {
 			"name": "Vaporeon",
@@ -8901,7 +8954,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"138": {
 			"name": "Omanyte",
@@ -9093,7 +9147,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"141": {
 			"name": "Kabutops",
@@ -9473,7 +9528,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"148": {
 			"name": "Dragonair",
@@ -9820,7 +9876,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"153": {
 			"name": "Bayleef",
@@ -9971,7 +10028,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"156": {
 			"name": "Quilava",
@@ -10123,7 +10181,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"159": {
 			"name": "Croconaw",
@@ -10275,7 +10334,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"162": {
 			"name": "Furret",
@@ -10375,7 +10435,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"164": {
 			"name": "Noctowl",
@@ -10476,7 +10537,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"166": {
 			"name": "Ledian",
@@ -10577,7 +10639,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"168": {
 			"name": "Ariados",
@@ -10726,7 +10789,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"171": {
 			"name": "Lanturn",
@@ -10825,7 +10889,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"173": {
 			"name": "Cleffa",
@@ -10876,7 +10941,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"174": {
 			"name": "Igglybuff",
@@ -10928,7 +10994,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"175": {
 			"name": "Togepi",
@@ -10979,7 +11046,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"176": {
 			"name": "Togetic",
@@ -11085,7 +11153,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"178": {
 			"name": "Xatu",
@@ -11204,7 +11273,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"180": {
 			"name": "Flaaffy",
@@ -11657,7 +11727,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"188": {
 			"name": "Skiploom",
@@ -11849,7 +11920,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"191": {
 			"name": "Sunkern",
@@ -11901,7 +11973,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"192": {
 			"name": "Sunflora",
@@ -12002,7 +12075,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"194": {
 			"name": "Wooper",
@@ -12074,7 +12148,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"195": {
 			"name": "Quagsire",
@@ -12288,7 +12363,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"199": {
 			"name": "Slowking",
@@ -12410,7 +12486,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"201": {
 			"name": "Unown",
@@ -12723,7 +12800,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"205": {
 			"name": "Forretress",
@@ -12892,7 +12970,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"208": {
 			"name": "Steelix",
@@ -13026,7 +13105,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"210": {
 			"name": "Granbull",
@@ -13368,7 +13448,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"216": {
 			"name": "Teddiursa",
@@ -13439,7 +13520,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"217": {
 			"name": "Ursaring",
@@ -13539,7 +13621,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"219": {
 			"name": "Magcargo",
@@ -13659,7 +13742,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"221": {
 			"name": "Piloswine",
@@ -13835,7 +13919,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"224": {
 			"name": "Octillery",
@@ -14105,7 +14190,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"229": {
 			"name": "Houndoom",
@@ -14270,7 +14356,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"232": {
 			"name": "Donphan",
@@ -14535,7 +14622,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"237": {
 			"name": "Hitmontop",
@@ -14635,7 +14723,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"239": {
 			"name": "Elekid",
@@ -14686,7 +14775,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"240": {
 			"name": "Magby",
@@ -14737,7 +14827,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"241": {
 			"name": "Miltank",
@@ -15048,7 +15139,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"247": {
 			"name": "Pupitar",
@@ -15378,7 +15470,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"253": {
 			"name": "Grovyle",
@@ -15567,7 +15660,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"256": {
 			"name": "Combusken",
@@ -15773,7 +15867,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"259": {
 			"name": "Marshtomp",
@@ -15979,7 +16074,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"262": {
 			"name": "Mightyena",
@@ -16122,7 +16218,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"264": {
 			"name": "Linoone",
@@ -16249,7 +16346,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"266": {
 			"name": "Silcoon",
@@ -16497,7 +16595,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"271": {
 			"name": "Lombre",
@@ -16672,7 +16771,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"274": {
 			"name": "Nuzleaf",
@@ -16845,7 +16945,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"277": {
 			"name": "Swellow",
@@ -16946,7 +17047,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"279": {
 			"name": "Pelipper",
@@ -17067,7 +17169,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"281": {
 			"name": "Kirlia",
@@ -17275,7 +17378,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"284": {
 			"name": "Masquerain",
@@ -17377,7 +17481,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"286": {
 			"name": "Breloom",
@@ -17476,7 +17581,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"288": {
 			"name": "Vigoroth",
@@ -17627,7 +17733,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"291": {
 			"name": "Ninjask",
@@ -17775,7 +17882,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"294": {
 			"name": "Loudred",
@@ -17945,7 +18053,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"297": {
 			"name": "Hariyama",
@@ -18046,7 +18155,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"299": {
 			"name": "Nosepass",
@@ -18116,7 +18226,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"300": {
 			"name": "Skitty",
@@ -18168,7 +18279,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"301": {
 			"name": "Delcatty",
@@ -18423,7 +18535,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"305": {
 			"name": "Lairon",
@@ -18614,7 +18727,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"308": {
 			"name": "Medicham",
@@ -18748,7 +18862,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"310": {
 			"name": "Manectric",
@@ -19105,7 +19220,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"317": {
 			"name": "Swalot",
@@ -19225,7 +19341,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"319": {
 			"name": "Sharpedo",
@@ -19339,7 +19456,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"321": {
 			"name": "Wailord",
@@ -19439,7 +19557,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"323": {
 			"name": "Camerupt",
@@ -19601,7 +19720,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"326": {
 			"name": "Grumpig",
@@ -19834,7 +19954,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"329": {
 			"name": "Vibrava",
@@ -20026,7 +20147,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"332": {
 			"name": "Cacturne",
@@ -20128,7 +20250,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"334": {
 			"name": "Altaria",
@@ -20431,7 +20554,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"340": {
 			"name": "Whiscash",
@@ -20531,7 +20655,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"342": {
 			"name": "Crawdaunt",
@@ -20633,7 +20758,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"344": {
 			"name": "Claydol",
@@ -20757,7 +20883,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"346": {
 			"name": "Cradily",
@@ -20878,7 +21005,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"348": {
 			"name": "Armaldo",
@@ -20976,7 +21104,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"350": {
 			"name": "Milotic",
@@ -21235,7 +21364,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"354": {
 			"name": "Banette",
@@ -21367,7 +21497,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"356": {
 			"name": "Dusclops",
@@ -21646,7 +21777,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"361": {
 			"name": "Snorunt",
@@ -21702,7 +21834,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"362": {
 			"name": "Glalie",
@@ -21835,7 +21968,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"364": {
 			"name": "Sealeo",
@@ -22009,7 +22143,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"367": {
 			"name": "Huntail",
@@ -22269,7 +22404,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"372": {
 			"name": "Shelgon",
@@ -22472,7 +22608,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"375": {
 			"name": "Metang",
@@ -23227,7 +23364,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"388": {
 			"name": "Grotle",
@@ -23418,7 +23556,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"391": {
 			"name": "Monferno",
@@ -23590,7 +23729,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"394": {
 			"name": "Prinplup",
@@ -23762,7 +23902,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"397": {
 			"name": "Staravia",
@@ -23953,7 +24094,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"400": {
 			"name": "Bibarel",
@@ -24051,7 +24193,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"402": {
 			"name": "Kricketune",
@@ -24150,7 +24293,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"404": {
 			"name": "Luxio",
@@ -24302,7 +24446,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"407": {
 			"name": "Roserade",
@@ -24404,7 +24549,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"409": {
 			"name": "Rampardos",
@@ -24504,7 +24650,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"411": {
 			"name": "Bastiodon",
@@ -24653,7 +24800,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"413": {
 			"name": "Wormadam",
@@ -24848,7 +24996,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"416": {
 			"name": "Vespiquen",
@@ -24999,7 +25148,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"419": {
 			"name": "Floatzel",
@@ -25103,7 +25253,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"421": {
 			"name": "Cherrim",
@@ -25237,7 +25388,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"423": {
 			"name": "Gastrodon",
@@ -25393,7 +25545,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"426": {
 			"name": "Drifblim",
@@ -25492,7 +25645,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"428": {
 			"name": "Lopunny",
@@ -25700,7 +25854,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"432": {
 			"name": "Purugly",
@@ -25799,7 +25954,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"434": {
 			"name": "Stunky",
@@ -25871,7 +26027,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"435": {
 			"name": "Skuntank",
@@ -25973,7 +26130,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"437": {
 			"name": "Bronzong",
@@ -26076,7 +26234,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"439": {
 			"name": "Mime Jr",
@@ -26129,7 +26288,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"440": {
 			"name": "Happiny",
@@ -26179,7 +26339,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"441": {
 			"name": "Chatot",
@@ -26347,7 +26508,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"444": {
 			"name": "Gabite",
@@ -26534,7 +26696,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"447": {
 			"name": "Riolu",
@@ -26585,7 +26748,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"448": {
 			"name": "Lucario",
@@ -26720,7 +26884,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"450": {
 			"name": "Hippowdon",
@@ -26842,7 +27007,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"452": {
 			"name": "Drapion",
@@ -26946,7 +27112,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"454": {
 			"name": "Toxicroak",
@@ -27093,7 +27260,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"457": {
 			"name": "Lumineon",
@@ -27193,7 +27361,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"459": {
 			"name": "Snover",
@@ -27265,7 +27434,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"460": {
 			"name": "Abomasnow",
@@ -29219,7 +29389,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"496": {
 			"name": "Servine",
@@ -29370,7 +29541,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"499": {
 			"name": "Pignite",
@@ -29524,7 +29696,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"502": {
 			"name": "Dewott",
@@ -29675,7 +29848,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"505": {
 			"name": "Watchog",
@@ -29774,7 +29948,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"507": {
 			"name": "Herdier",
@@ -29926,7 +30101,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"510": {
 			"name": "Liepard",
@@ -30026,7 +30202,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"512": {
 			"name": "Simisage",
@@ -30125,7 +30302,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"514": {
 			"name": "Simisear",
@@ -30224,7 +30402,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"516": {
 			"name": "Simipour",
@@ -30323,7 +30502,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"518": {
 			"name": "Musharna",
@@ -30423,7 +30603,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"520": {
 			"name": "Tranquill",
@@ -30576,7 +30757,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"523": {
 			"name": "Zebstrika",
@@ -30675,7 +30857,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"525": {
 			"name": "Boldore",
@@ -30828,7 +31011,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"528": {
 			"name": "Swoobat",
@@ -30928,7 +31112,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"530": {
 			"name": "Excadrill",
@@ -31095,7 +31280,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"533": {
 			"name": "Gurdurr",
@@ -31246,7 +31432,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"536": {
 			"name": "Palpitoad",
@@ -31494,7 +31681,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"541": {
 			"name": "Swadloon",
@@ -31649,7 +31837,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"544": {
 			"name": "Whirlipede",
@@ -31804,7 +31993,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"547": {
 			"name": "Whimsicott",
@@ -31903,7 +32093,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"549": {
 			"name": "Lilligant",
@@ -32046,7 +32237,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"552": {
 			"name": "Krokorok",
@@ -32228,7 +32420,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"555": {
 			"name": "Darmanitan",
@@ -32422,7 +32615,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"558": {
 			"name": "Crustle",
@@ -32523,7 +32717,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"560": {
 			"name": "Scrafty",
@@ -32712,7 +32907,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"563": {
 			"name": "Cofagrigus",
@@ -32812,7 +33008,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"565": {
 			"name": "Carracosta",
@@ -32913,7 +33110,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"567": {
 			"name": "Archeops",
@@ -33013,7 +33211,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"569": {
 			"name": "Garbodor",
@@ -33113,7 +33312,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"571": {
 			"name": "Zoroark",
@@ -33212,7 +33412,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"573": {
 			"name": "Cinccino",
@@ -33311,7 +33512,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"575": {
 			"name": "Gothorita",
@@ -33462,7 +33664,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"578": {
 			"name": "Duosion",
@@ -33614,7 +33817,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"581": {
 			"name": "Swanna",
@@ -33714,7 +33918,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"583": {
 			"name": "Vanillish",
@@ -33889,7 +34094,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"586": {
 			"name": "Sawsbuck",
@@ -34043,7 +34249,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"589": {
 			"name": "Escavalier",
@@ -34145,7 +34352,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"591": {
 			"name": "Amoonguss",
@@ -34262,7 +34470,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"593": {
 			"name": "Jellicent",
@@ -34414,7 +34623,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"596": {
 			"name": "Galvantula",
@@ -34517,7 +34727,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"598": {
 			"name": "Ferrothorn",
@@ -34619,7 +34830,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"600": {
 			"name": "Klang",
@@ -34769,7 +34981,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"603": {
 			"name": "Eelektrik",
@@ -34921,7 +35134,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"606": {
 			"name": "Beheeyem",
@@ -35021,7 +35235,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"608": {
 			"name": "Lampent",
@@ -35176,7 +35391,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"611": {
 			"name": "Fraxure",
@@ -35337,7 +35553,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"614": {
 			"name": "Beartic",
@@ -35484,7 +35701,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"617": {
 			"name": "Accelgor",
@@ -35652,7 +35870,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"620": {
 			"name": "Mienshao",
@@ -35799,7 +36018,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"623": {
 			"name": "Golurk",
@@ -35900,7 +36120,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"625": {
 			"name": "Bisharp",
@@ -36050,7 +36271,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"628": {
 			"name": "Braviary",
@@ -36152,7 +36374,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"630": {
 			"name": "Mandibuzz",
@@ -36349,7 +36572,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"634": {
 			"name": "Zweilous",
@@ -36503,7 +36727,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"637": {
 			"name": "Volcarona",
@@ -37254,7 +37479,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"651": {
 			"name": "Quilladin",
@@ -37372,7 +37598,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"654": {
 			"name": "Braixen",
@@ -37490,7 +37717,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"657": {
 			"name": "Frogadier",
@@ -37607,7 +37835,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"660": {
 			"name": "Diggersby",
@@ -37685,7 +37914,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"662": {
 			"name": "Fletchinder",
@@ -37802,7 +38032,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"665": {
 			"name": "Spewpa",
@@ -38004,7 +38235,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"668": {
 			"name": "Pyroar",
@@ -38115,7 +38347,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"670": {
 			"name": "Floette",
@@ -38267,7 +38500,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"673": {
 			"name": "Gogoat",
@@ -38342,7 +38576,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"675": {
 			"name": "Pangoro",
@@ -38501,7 +38736,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"678": {
 			"name": "Meowstic",
@@ -38589,7 +38825,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"680": {
 			"name": "Doublade",
@@ -38702,7 +38939,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"683": {
 			"name": "Aromatisse",
@@ -38774,7 +39012,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"685": {
 			"name": "Slurpuff",
@@ -38848,7 +39087,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"687": {
 			"name": "Malamar",
@@ -38924,7 +39164,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"689": {
 			"name": "Barbaracle",
@@ -39003,7 +39244,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"691": {
 			"name": "Dragalge",
@@ -39080,7 +39322,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"693": {
 			"name": "Clawitzer",
@@ -39155,7 +39398,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"695": {
 			"name": "Heliolisk",
@@ -39232,7 +39476,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"697": {
 			"name": "Tyrantrum",
@@ -39310,7 +39555,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"699": {
 			"name": "Aurorus",
@@ -39528,7 +39774,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"705": {
 			"name": "Sliggoo",
@@ -39680,7 +39927,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"709": {
 			"name": "Trevenant",
@@ -39770,7 +40018,8 @@
 			"mythic": false,
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
-			"third_move_candy": 75
+			"third_move_candy": 75,
+			"little": true
 		},
 		"711": {
 			"name": "Gourgeist",
@@ -39859,7 +40108,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"713": {
 			"name": "Avalugg",
@@ -39936,7 +40186,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"715": {
 			"name": "Noivern",
@@ -40183,7 +40434,8 @@
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
 			"third_move_candy": 100,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"809": {
 			"name": "Melmetal",


### PR DESCRIPTION
A whitelist is used, as opposed to blacklist in gamemaster. It does not pull ban list from gamemaster directly, instead it uses it to check whether the output is consistent.

Special cases hardcoded:

* `FARFETCHD_GALARIAN`
* ~~`OMANYTE`~~
* `DEERLING`

Sample output from Chuck PR in progress:

```json
{
 "little":[{"pokemon":682,"cap":40,"value":380072,"level":15,"cp":485,"percentage":0.89755,"rank":3557,"capped":true}],
 "great":[{"pokemon":683,"cap":40,"value":1858281,"level":24,"cp":1492,"percentage":0.94796,"rank":2157,"capped":true}],
 "ultra":[{"pokemon":683,"cap":50,"value":3947856,"level":50,"cp":2459,"percentage":0.94742,"rank":1787},{"pokemon":683,"cap":51,"value":4015784,"level":51,"cp":2489,"percentage":0.95808,"rank":1241}]
}
```