### PR TITLE
delete unchanged previous files

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -68,7 +68,7 @@ const masterfile = async function update() {
 
       // compare content of both files
       var newFile = fs.readFileSync(`./${templateName}`)
-      var previousFile = fs.readFileSync(previousFilePath)
+      const previousFile = fs.readFileSync(previousFilePath)
       if (previousFile.equals(newFile)) {
         fs.unlinkSync(previousFilePath, (err => {
           if (err) console.error(err);

--- a/generate.js
+++ b/generate.js
@@ -67,7 +67,7 @@ const masterfile = async function update() {
       fs.writeFileSync(`./${templateName}`, JSON.stringify(newData, null, 2), 'utf8', () => { })
 
       // compare content of both files
-      var newFile = fs.readFileSync(`./${templateName}`)
+      const newFile = fs.readFileSync(`./${templateName}`)
       const previousFile = fs.readFileSync(previousFilePath)
       if (previousFile.equals(newFile)) {
         fs.unlinkSync(previousFilePath, (err => {

--- a/generate.js
+++ b/generate.js
@@ -36,8 +36,9 @@ const masterfile = async function update() {
   }
 
   await Promise.all(templates.map(async templateName => {
+    const previousFilePath = `./previous-versions/${sha}/${templateName}`
     try {
-      fs.writeFileSync(`./previous-versions/${sha}/${templateName}`, fs.readFileSync(`./${templateName}`), 'utf8', () => { })
+      fs.writeFileSync(previousFilePath, fs.readFileSync(`./${templateName}`), 'utf8', () => { })
     } catch (e) {
       console.warn(`Previous version of ${templateName} does not exist`)
     }
@@ -64,6 +65,18 @@ const masterfile = async function update() {
         delete newData.translations
       }
       fs.writeFileSync(`./${templateName}`, JSON.stringify(newData, null, 2), 'utf8', () => { })
+
+      // compare content of both files
+      var newFile = fs.readFileSync(`./${templateName}`)
+      var previousFile = fs.readFileSync(previousFilePath)
+      if (previousFile.equals(newFile)) {
+        fs.unlinkSync(previousFilePath, (err => {
+          if (err) console.error(err);
+          else  {
+            console.log(`Deleted file ${templateName}`)
+          }
+        }))
+      }
 
       if (templateName === 'master-latest.json') {
         const pokedex = []


### PR DESCRIPTION
As there is now a daily sync it's annoying to create a daily commit if nothing changed. therefore I added a comparison of content, if it's unchanged we delete old file again. if the newly created directory `previous-versions/$sha` is empty it should not be commited and therefor the workflow does not create a commit :+1: 