### PR TITLE
fix: poracle-v2 template

### DIFF
--- a/templates/master-latest-poracle-v2.json
+++ b/templates/master-latest-poracle-v2.json
@@ -171,7 +171,8 @@
     "enabled": true,
     "options": {
       "masterfileLocale": "en",
-      "manualTranslations": true
+      "manualTranslations": true,
+      "useLanguageAsRef": false
     },
     "locales": {
       "en": true,


### PR DESCRIPTION
Not exactly sure.. But when I removed the manual translations in pogo-translations, this file got updated... even if in pogo-translations the static translations were unchanged. so somehow this template reads from manual translations as well

I tried to compare other templates, but all of them defined "manualTranslations: true" and the change in pogo-translations did not affect the generation of them.

@TurtIeSocks you know better how this works, if you find some time pls check if this change would fix the behavior :) 

https://github.com/WatWowMap/pogo-translations/pull/40/files